### PR TITLE
Add COLMAP data support and fix GCC 13 / CUDA 12.x build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,27 @@ pip install -r requirements.txt
 Build differentiable Gaussian rasterizer
 ```
 cd diff-gaussian-rasterization
-pip install .
+pip install --no-build-isolation .
 ```
+
+> **Note for GCC 13 + CUDA 12.4+ users:** If you encounter compilation errors related to `cospi`/`sinpi` exception specification conflicts, patch the CUDA math header before building:
+> ```python
+> sudo python3 -c "
+> path = '/usr/local/cuda-12.6/include/crt/math_functions.h'
+> with open(path) as f: content = f.read()
+> content = content.replace('double                 sinpi(double x);', 'double                 sinpi(double x) noexcept;')
+> content = content.replace('float                  sinpif(float x);', 'float                  sinpif(float x) noexcept;')
+> content = content.replace('double                 cospi(double x);', 'double                 cospi(double x) noexcept;')
+> content = content.replace('float                  cospif(float x);', 'float                  cospif(float x) noexcept;')
+> with open(path, 'w') as f: f.write(content)
+> "
+> ```
+> Adjust the path to match your CUDA version (e.g. `/usr/local/cuda-12.1/...`).
+
+> **Note on package versions:** If you encounter import errors with `diffusers`, pin to a compatible version:
+> ```
+> pip install "diffusers==0.32.2" "transformers==4.44.2"
+> ```
 
 ## Usage
 ### Training from scratch
@@ -164,7 +183,65 @@ Please refer to [here](https://github.com/GS-Fusion/GSFusion_eval#file-structure
 
 </details>
 
-## Testing on your own data
+## Testing on your own data (COLMAP format)
+
+If your data comes from COLMAP reconstruction (e.g. from RealityScan, Metashape, or similar), use the dedicated COLMAP pipeline which bypasses the interactive mesh viewer.
+
+**Supported input:** A folder containing `cameras.txt`, `images.txt`, `points3D.txt`, and the original images, plus a 3DGS model trained on that data.
+
+### Step 1 — Prepare the 3DGS model directory
+
+GSFix3D expects the Inria 3DGS format. If your model is a single `.ply` file (e.g. from PostShot), create the expected structure:
+```bash
+mkdir -p <gs_model_path>/point_cloud/iteration_<N>
+ln -s /path/to/your/splat.ply <gs_model_path>/point_cloud/iteration_<N>/point_cloud.ply
+```
+
+Also create a minimal `cfg_args` file in `<gs_model_path>`:
+```
+Namespace(sh_degree=3, source_path='', model_path='<gs_model_path>', images='images', resolution=-1, white_background=False, data_device='cuda', eval=False)
+```
+
+### Step 2 — Select and render novel views
+
+Use the COLMAP-aware script to sample existing camera poses and render GS images (no mesh or display required):
+```bash
+python scripts/gsfix3d/colmap_to_novel_views.py \
+  -m <gs_model_path> \
+  --data_path <colmap_data_path> \
+  --output_dir <output_path>/novel_views \
+  --stride 10
+```
+`--stride 10` uses every 10th camera. Adjust to control the number of views. Use `--max_views N` to cap the total.
+
+### Step 3 — Run GSFixer inference
+
+```bash
+python scripts/gsfixer/inference.py \
+  --checkpoint <gsfixer_checkpoint_path> \
+  --data_type colmap \
+  --data_path <output_path>/novel_views \
+  --recon_method_type custom \
+  --output_dir <output_path>/gsfixer_output
+```
+
+Note: use `gsfixer-base` (GS-only, single input) unless you have rendered mesh images, in which case use `gsfixer-full` with `--dual_input`.
+
+### Step 4 — Lift fixed views back into 3DGS
+
+```bash
+python scripts/gsfix3d/refine_gs.py \
+  -m <gs_model_path> \
+  --data_type colmap \
+  --data_path <colmap_data_path> \
+  --fixed_image_path <output_path>/gsfixer_output/rgb \
+  --novel_views <output_path>/novel_views/novel_views.json \
+  --output_dir <output_path>/gsfix3d_output
+```
+
+The refined model is saved as `<output_path>/gsfix3d_output/point_cloud.ply`.
+
+## Testing on your own data (interactive, with mesh)
 
 Prepare the novel views that you want to repair using our provided script
 ```

--- a/gs/arguments.py
+++ b/gs/arguments.py
@@ -111,8 +111,8 @@ def get_combined_args(parser : ArgumentParser):
         with open(cfgfilepath) as cfg_file:
             print("Config file found: {}".format(cfgfilepath))
             cfgfile_string = cfg_file.read()
-    except TypeError:
-        print("Config file not found at")
+    except (TypeError, FileNotFoundError):
+        print("Config file not found at", cfgfilepath)
         pass
     args_cfgfile = eval(cfgfile_string)
 

--- a/scripts/gsfix3d/colmap_to_novel_views.py
+++ b/scripts/gsfix3d/colmap_to_novel_views.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025
+# SPDX-License-Identifier: Apache-2.0
+#
+# Replaces the interactive novel_view_capture.py for COLMAP data.
+# Reads existing COLMAP camera poses, exports novel_views.json,
+# and renders GS images from each selected pose.
+
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+import json
+import argparse
+import numpy as np
+from PIL import Image
+from tqdm import tqdm
+import torch
+
+from gs.camera import Camera
+from gs.gaussian_model import GaussianModel
+from gs.gaussian_renderer import render
+from gs.general_utils import searchForMaxIteration, focal2fov
+from gs.arguments import ModelParams, PipelineParams, get_combined_args
+from scripts.utils import read_colmap_cameras
+
+
+def main(args, model_params, pipeline_params):
+    # Load camera poses from COLMAP
+    train_cameras, _, intrinsics = read_colmap_cameras(args.data_path)
+    print(f"Loaded {len(train_cameras)} cameras from COLMAP.")
+
+    # Select a subset using stride (every Nth camera)
+    indices = list(range(0, len(train_cameras), args.stride))
+    if args.max_views > 0:
+        indices = indices[:args.max_views]
+    print(f"Selected {len(indices)} cameras (stride={args.stride}).")
+
+    # Build novel_views.json (T_CW extrinsic matrices)
+    novel_views = []
+    for idx in indices:
+        T_WC = train_cameras[idx]
+        T_CW = np.linalg.inv(T_WC)
+        novel_views.append({"extrinsic": T_CW.tolist()})
+
+    poses_file = os.path.join(args.output_dir, "novel_views.json")
+    with open(poses_file, "w") as f:
+        json.dump(novel_views, f, indent=4)
+    print(f"Saved {len(novel_views)} poses to {poses_file}")
+
+    # Set up renderer
+    if args.iteration == -1:
+        loaded_iter = searchForMaxIteration(os.path.join(model_params.model_path, "point_cloud"))
+    else:
+        loaded_iter = args.iteration
+
+    if torch.cuda.is_available():
+        device = torch.device("cuda:0")
+        torch.cuda.set_device(device)
+    else:
+        raise Exception("No GPU found!")
+
+    gaussians = GaussianModel(model_params.sh_degree)
+    gaussians.load_ply(os.path.join(model_params.model_path,
+                                    "point_cloud",
+                                    "iteration_" + str(loaded_iter),
+                                    "point_cloud.ply"))
+
+    fov_x = focal2fov(intrinsics["fx"], intrinsics["width"])
+    fov_y = focal2fov(intrinsics["fy"], intrinsics["height"])
+    bg_color = [1, 1, 1] if model_params.white_background else [0, 0, 0]
+    background = torch.tensor(bg_color, dtype=torch.float32, device=device)
+
+    gs_image_dir = os.path.join(args.output_dir, "rendered_novel_views", "gs_image")
+    os.makedirs(gs_image_dir, exist_ok=True)
+
+    print("Rendering GS images from selected poses...")
+    for i, pose in tqdm(enumerate(novel_views), total=len(novel_views)):
+        T_CW = np.array(pose["extrinsic"])
+        gs_cam = Camera(
+            R=T_CW[:3, :3], T=T_CW[:3, 3],
+            FoVx=fov_x, FoVy=fov_y,
+            width=intrinsics["width"], height=intrinsics["height"]
+        )
+        with torch.no_grad():
+            rendered = render(gs_cam, gaussians, pipeline_params, background)["render"]
+            img = rendered.detach().cpu().numpy().transpose(1, 2, 0) * 255
+            img = img.astype(np.uint8)
+            Image.fromarray(img).save(os.path.join(gs_image_dir, f"{i:05d}.png"))
+
+    print(f"Done. Rendered images saved to {gs_image_dir}")
+    print(f"Novel views JSON saved to {poses_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert COLMAP cameras to novel views for GSFix3D")
+
+    model = ModelParams(parser, sentinel=True)
+    pipeline = PipelineParams(parser)
+
+    parser.add_argument("--data_path", type=str, required=True, help="Path to folder with cameras.txt and images.txt")
+    parser.add_argument("--output_dir", type=str, required=True, help="Output folder for novel_views.json and rendered images")
+    parser.add_argument("--stride", type=int, default=10, help="Use every Nth camera (default: 10)")
+    parser.add_argument("--max_views", type=int, default=0, help="Max number of views to use (0 = no limit)")
+    parser.add_argument("--iteration", type=int, default=-1, help="Which 3DGS iteration to load (-1 = latest)")
+
+    args = get_combined_args(parser)
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    main(args, model.extract(args), pipeline.extract(args))

--- a/scripts/gsfix3d/novel_view_capture.py
+++ b/scripts/gsfix3d/novel_view_capture.py
@@ -20,7 +20,7 @@ from gs.gaussian_renderer import render
 from gs.general_utils import searchForMaxIteration, focal2fov
 from gs.arguments import ModelParams, PipelineParams, get_combined_args
 
-from scripts.utils import read_replica_cameras, read_scannetpp_cameras, render_mesh
+from scripts.utils import read_replica_cameras, read_scannetpp_cameras, read_colmap_cameras, render_mesh
 
 
 def save_camera_poses(vis):
@@ -64,6 +64,8 @@ def main(args, model_params, pipeline_params):
         intrinsics = read_replica_cameras(args.data_path, intrinsics_only=True)
     elif args.data_type == "scannetpp":
         intrinsics = read_scannetpp_cameras(args.data_path, intrinsics_only=True)
+    elif args.data_type == "colmap":
+        intrinsics = read_colmap_cameras(args.data_path, intrinsics_only=True)
     else:
         raise TypeError(f"Unsupported dataset type: {args.data_type}!")
 
@@ -72,13 +74,19 @@ def main(args, model_params, pipeline_params):
     )
 
     mesh_file = os.path.join(model_params.model_path, "mesh", "mesh_" + str(loaded_iter) + ".ply")
-    if not os.path.exists(mesh_file):
-        raise FileNotFoundError(f"{mesh_file} doesn't exist!")
-    mesh = o3d.io.read_triangle_mesh(mesh_file)
+    mesh = None
+    if os.path.exists(mesh_file):
+        mesh = o3d.io.read_triangle_mesh(mesh_file)
+        geometry = mesh
+    else:
+        print(f"No mesh found at {mesh_file}, using Gaussian point cloud for visualization.")
+        ply_path = os.path.join(model_params.model_path, "point_cloud", "iteration_" + str(loaded_iter), "point_cloud.ply")
+        pcd = o3d.io.read_point_cloud(ply_path)
+        geometry = pcd
 
     vis = o3d.visualization.VisualizerWithKeyCallback()
     vis.create_window(width=intrinsics["width"], height=intrinsics["height"])
-    vis.add_geometry(mesh)
+    vis.add_geometry(geometry)
     vis.register_key_callback(ord("R"), R_key_callback)
     vis.register_key_callback(ord("Q"), Q_key_callback)
 
@@ -115,7 +123,7 @@ def main(args, model_params, pipeline_params):
         T_WC = np.linalg.inv(T_CW)
         
         # Render mesh
-        if render_mesh:
+        if args.render_mesh and mesh is not None:
             rgb = render_mesh(mesh, intrinsics, T_WC[:3, :3], T_WC[:3, 3])
             rgb = rgb.astype(np.uint8)
             save_path = os.path.join(sub_dir, "mesh_image", f"{i:05d}.png")
@@ -138,7 +146,7 @@ if __name__ == "__main__":
     pipeline = PipelineParams(parser)
 
     parser.add_argument("--iteration", type=int, default=-1, help="A 3DGS model from this specific iteration will be loaded following Inria 3DGS file structure")
-    parser.add_argument("--data_type", type=str, default="replica", choices=["replica", "scannetpp"], help="Supported data type")
+    parser.add_argument("--data_type", type=str, default="replica", choices=["replica", "scannetpp", "colmap"], help="Supported data type")
     parser.add_argument("--data_path", type=str, help="Path to your customized data")
     parser.add_argument("--render_mesh", action="store_true", help="Enable mesh image rendering")
     parser.add_argument("--output_dir", type=str, default="output_novel_views", help="Folder path to store results")
@@ -147,7 +155,7 @@ if __name__ == "__main__":
     os.makedirs(args.output_dir, exist_ok=True)
     sub_dir = os.path.join(args.output_dir, "rendered_novel_views")
     os.makedirs(os.path.join(sub_dir, "gs_image"), exist_ok=True)
-    if render_mesh:
+    if args.render_mesh:
         os.makedirs(os.path.join(sub_dir, "mesh_image"), exist_ok=True)
 
     POSES_FILE = os.path.join(args.output_dir, "novel_views.json")

--- a/scripts/gsfix3d/refine_gs.py
+++ b/scripts/gsfix3d/refine_gs.py
@@ -149,7 +149,8 @@ def main(args, model_params, optim_params, pipeline_params):
             T_kf_inv = np.linalg.inv(T_kf)
             gs_cam_kf = Camera(R=T_kf_inv[:3, :3], T=T_kf_inv[:3, 3], FoVx=fov_x, FoVy=fov_y, width=intrinsics["width"], height=intrinsics["height"])
             
-            kf_img = Image.open(train_rgb_file_paths[kf_idx])
+            kf_img = Image.open(train_rgb_file_paths[kf_idx]).convert("RGB")
+            kf_img = kf_img.resize((intrinsics["width"], intrinsics["height"]), Image.BILINEAR)
             gt_image = to_tensor(kf_img)
             gt_image = gt_image.cuda()
 

--- a/scripts/gsfix3d/refine_gs.py
+++ b/scripts/gsfix3d/refine_gs.py
@@ -24,7 +24,7 @@ from gs.general_utils import searchForMaxIteration, focal2fov
 from gs.loss_utils import l1_loss, ssim
 from gs.arguments import ModelParams, OptimizationParams, PipelineParams, get_combined_args
 
-from scripts.utils import read_replica_cameras, read_scannetpp_cameras, eval_image
+from scripts.utils import read_replica_cameras, read_scannetpp_cameras, read_colmap_cameras, eval_image
 
 
 def main(args, model_params, optim_params, pipeline_params):
@@ -54,6 +54,15 @@ def main(args, model_params, optim_params, pipeline_params):
         train_rgb_file_paths = sorted([os.path.join(args.data_path, "undistorted_images_2", file_name) for file_name in splits["train"]])
         test_rgb_file_paths = sorted([os.path.join(args.data_path, "undistorted_images_2", file_name) for file_name in splits["test"]])
         train_camera_poses, test_camera_poses, intrinsics = read_scannetpp_cameras(args.data_path)
+    elif args.data_type == "colmap":
+        from glob import glob as _glob
+        train_rgb_file_paths = sorted(
+            _glob(os.path.join(args.data_path, "*.png")) +
+            _glob(os.path.join(args.data_path, "*.jpg"))
+        )
+        test_rgb_file_paths = []
+        train_camera_poses, _, intrinsics = read_colmap_cameras(args.data_path)
+        train_camera_poses = list(train_camera_poses)
     else:
         raise TypeError(f"Unsupported dataset type: {args.data_type}!")
 
@@ -189,7 +198,7 @@ if __name__ == "__main__":
     pipeline = PipelineParams(parser)
     
     parser.add_argument("--iteration", type=int, default=-1, help="A 3DGS model from this specific iteration will be loaded following Inria 3DGS file structure")
-    parser.add_argument("--data_type", type=str, default="replica", choices=["replica", "scannetpp"], help="Supported data type")
+    parser.add_argument("--data_type", type=str, default="replica", choices=["replica", "scannetpp", "colmap"], help="Supported data type")
     parser.add_argument("--data_path", type=str, help="Path to ground truth data")
     parser.add_argument("--sparse_kf_list", type=str, default="", help="A keyframe list to only select keyframes from ground truth data")
     parser.add_argument("--fixed_image_path", type=str, help="Path to fixed novel view images obtained from GSFixer")

--- a/scripts/gsfixer/inference.py
+++ b/scripts/gsfixer/inference.py
@@ -70,7 +70,7 @@ if "__main__" == __name__:
         "--data_type",
         type=str,
         default="replica",
-        choices=["replica", "scannetpp"]
+        choices=["replica", "scannetpp", "colmap"]
     )
     parser.add_argument(
         "--data_path",
@@ -192,6 +192,8 @@ if "__main__" == __name__:
             with open(split_file, "r") as f:
                 splits = json.load(f)
             gt_rgb_file_paths = sorted([os.path.join(args.data_path, "undistorted_images_2", file_name) for file_name in splits["test"]])
+        elif args.data_type == "colmap":
+            gt_rgb_file_paths = []  # no predefined ground truth for custom data
         else:
             raise TypeError(f"Unsupported dataset type: {args.data_type}!")
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -129,6 +129,76 @@ def render_mesh(mesh, intrinsics, R_WC, t_WC):
     return color
 
 
+def read_colmap_cameras(path, intrinsics_only=False):
+    """Read cameras from COLMAP format (cameras.txt, images.txt)."""
+    cameras_file = os.path.join(path, "cameras.txt")
+    images_file = os.path.join(path, "images.txt")
+
+    # Read per-camera intrinsics
+    cam_params = {}
+    with open(cameras_file, 'r') as f:
+        for line in f:
+            if line.startswith('#') or not line.strip():
+                continue
+            parts = line.strip().split()
+            cam_id = int(parts[0])
+            model = parts[1]
+            width, height = int(parts[2]), int(parts[3])
+            if model == "SIMPLE_RADIAL" or model == "SIMPLE_PINHOLE":
+                fx = fy = float(parts[4])
+                cx, cy = float(parts[5]), float(parts[6])
+            elif model == "PINHOLE" or model == "OPENCV":
+                fx, fy = float(parts[4]), float(parts[5])
+                cx, cy = float(parts[6]), float(parts[7])
+            else:
+                fx = fy = float(parts[4])
+                cx, cy = float(parts[5]), float(parts[6])
+            cam_params[cam_id] = {"width": width, "height": height, "fx": fx, "fy": fy, "cx": cx, "cy": cy}
+
+    # Use the most common width/height; average intrinsics across all cameras
+    widths = [c["width"] for c in cam_params.values()]
+    heights = [c["height"] for c in cam_params.values()]
+    width = max(set(widths), key=widths.count)
+    height = max(set(heights), key=heights.count)
+    intrinsics = {
+        "width": width,
+        "height": height,
+        "fx": float(np.mean([c["fx"] for c in cam_params.values()])),
+        "fy": float(np.mean([c["fy"] for c in cam_params.values()])),
+        "cx": float(np.mean([c["cx"] for c in cam_params.values()])),
+        "cy": float(np.mean([c["cy"] for c in cam_params.values()])),
+    }
+
+    if intrinsics_only:
+        return intrinsics
+
+    # Read poses from images.txt (2 lines per image: pose + 2D points)
+    image_poses = {}
+    with open(images_file, 'r') as f:
+        lines = [l.strip() for l in f if not l.startswith('#') and l.strip()]
+
+    i = 0
+    while i < len(lines):
+        parts = lines[i].split()
+        if len(parts) >= 10:
+            qw, qx, qy, qz = float(parts[1]), float(parts[2]), float(parts[3]), float(parts[4])
+            tx, ty, tz = float(parts[5]), float(parts[6]), float(parts[7])
+            name = parts[9]
+            # COLMAP stores world-to-camera transform; convert to camera-to-world (T_WC)
+            R_cw = R.from_quat([qx, qy, qz, qw]).as_matrix()
+            t_cw = np.array([tx, ty, tz])
+            T_CW = np.eye(4)
+            T_CW[:3, :3] = R_cw
+            T_CW[:3, 3] = t_cw
+            image_poses[name] = np.linalg.inv(T_CW)
+        i += 2  # skip 2D-points line
+
+    sorted_names = sorted(image_poses.keys())
+    train_cameras = np.stack([image_poses[n] for n in sorted_names])
+
+    return train_cameras, None, intrinsics
+
+
 def read_replica_cameras(path, intrinsics_only=False):
     parent_path = os.path.dirname(path)
     intrinsics_path = os.path.join(parent_path, "cam_params.json")


### PR DESCRIPTION
## Summary

- **COLMAP support**: adds `--data_type colmap` to all three pipeline scripts (`inference.py`, `refine_gs.py`, `novel_view_capture.py`) and a new `colmap_to_novel_views.py` script that replaces the interactive Open3D viewer for COLMAP data — no mesh or display required
- **Build fix**: resolves compilation failures on GCC 13 + CUDA 12.4+ caused by exception-spec conflicts between CUDA's `math_functions.h` and glibc's `cospi`/`sinpi` declarations; removes the problematic `-U_GNU_SOURCE` flag
- **Bug fix**: `novel_view_capture.py` `--render_mesh` flag was silently ignored due to name shadowing with the imported function
- **Robustness**: `gs/arguments.py` now catches `FileNotFoundError` for missing `cfg_args` files (e.g. models trained outside the Inria codebase)

## COLMAP workflow (new)

For data from RealityScan, Metashape, PostShot, or any COLMAP reconstruction:

```bash
# 1. Sample existing camera poses and render GS images
python scripts/gsfix3d/colmap_to_novel_views.py \
  -m <gs_model_path> --data_path <colmap_path> \
  --output_dir <out>/novel_views --stride 10

# 2. Fix with GSFixer
python scripts/gsfixer/inference.py \
  --checkpoint <checkpoint> --data_type colmap \
  --data_path <out>/novel_views --recon_method_type custom \
  --output_dir <out>/gsfixer_output

# 3. Lift back into 3DGS
python scripts/gsfix3d/refine_gs.py \
  -m <gs_model_path> --data_type colmap \
  --data_path <colmap_path> \
  --fixed_image_path <out>/gsfixer_output/rgb \
  --novel_views <out>/novel_views/novel_views.json \
  --output_dir <out>/gsfix3d_output
```

## Test plan

- [x] Tested end-to-end on RealityScan COLMAP data (615 cameras, SIMPLE_RADIAL model) with `gsfixer-base` checkpoint on Ubuntu 24, Python 3.11, CUDA 12.6, GCC 13, RTX GPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)